### PR TITLE
Upgrade bcprov-jdk15on to version 1.66

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,5 +21,10 @@
             <version>1.0.0.RELEASE</version>
         </dependency>
 
-    </dependencies>
+      <dependency xmlns="">
+         <groupId>org.bouncycastle</groupId>
+         <artifactId>bcprov-jdk15on</artifactId>
+         <version>1.66</version>
+      </dependency>
+   </dependencies>
 </project>


### PR DESCRIPTION
![large-logo-191x34](https://user-images.githubusercontent.com/33268211/98482806-aa4ffd00-21b8-11eb-8a44-82947e3acf9a.png)<p>Upgrades bcprov-jdk15on to 1.66 to fix vulnerabilities in current version